### PR TITLE
Avoid deprecation of ensure_package

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -29,5 +29,5 @@ class mit_krb5::install($packages = undef) {
       'Suse'      => ['krb5-client'],
     }
   }
-  ensure_packages($install)
+  stdlib::ensure_packages($install)
 }

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=4.13.0 <9.0.0"
+      "version_requirement": ">=9.0.0 <10.0.0"
     },
     {
       "name": "puppetlabs/concat",


### PR DESCRIPTION
With puppetlabs-stdlib version 9:

```
juin 10 20:18:41 isaac puppet[23883]: Warning: This function is deprecated, please use stdlib::ensure_packages instead. at ["/etc/puppetlabs/code/environments/production/modules/mit_krb5/manifests/install.pp", 32]:["/etc/puppetlabs/code/environments/production/site.pp", 15]
```